### PR TITLE
Modified extension for Jekyll 3+ compatibility

### DIFF
--- a/lib/octopress-escape-code.rb
+++ b/lib/octopress-escape-code.rb
@@ -41,7 +41,7 @@ module Octopress
     end
 
     def escape(page)
-      ext = page.ext.downcase
+      ext = page.data['ext'].downcase
       content = page.content.encode!("UTF-8")
       md_ext = %w{.markdown .mdown .mkdn .md .mkd .mdwn .mdtxt .mdtext}
 


### PR DESCRIPTION
Changed access to the extension of an item, so Jekyll doesn't emit deprecation-warnings anymore.