### PR TITLE
Using extname instead ext

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - 2.0.0
+  - 2.6.0
 script: bundle exec clash
 notifications:
   slack:

--- a/lib/octopress-escape-code.rb
+++ b/lib/octopress-escape-code.rb
@@ -41,7 +41,7 @@ module Octopress
     end
 
     def escape(page)
-      ext = page.ext.downcase
+      ext = page.extname.downcase
       content = page.content.encode!("UTF-8")
       md_ext = %w{.markdown .mdown .mkdn .md .mkd .mdwn .mdtxt .mdtext}
 

--- a/octopress-escape-code.gemspec
+++ b/octopress-escape-code.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'jekyll', '~> 3.0'
 
-  spec.add_development_dependency "bundler", "~> 1.6"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "redcarpet"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "clash"

--- a/test/_expected/indented-codefence.html
+++ b/test/_expected/indented-codefence.html
@@ -1,6 +1,6 @@
 <p>Here’s some code:</p>
 
-<div class="highlighter-rouge"><pre class="highlight"><code>```ruby mark:2-4 title:"Testing codefence" url:"https://github.com/octopress/codefence" link_text:"plugin link"
+<div class="highlighter-rouge"><div class="highlight"><pre class="highlight"><code>```ruby mark:2-4 title:"Testing codefence" url:"https://github.com/octopress/codefence" link_text:"plugin link"
 class Float
   def number_decimal_places
     self.to_s.length-2
@@ -25,7 +25,6 @@ class Float
   end
 end
 ```
-</code></pre>
-</div>
+</code></pre></div></div>
 
 <p>How’d we do?</p>

--- a/test/_expected/index.html
+++ b/test/_expected/index.html
@@ -1,11 +1,10 @@
 <p>Some text</p>
 
-<div class="highlighter-rouge"><pre class="highlight"><code> `stuff`
+<div class="highlighter-rouge"><div class="highlight"><pre class="highlight"><code> `stuff`
 Some kind of example:
     {% some tag that should break %}
 Stuff!
-</code></pre>
-</div>
+</code></pre></div></div>
 
 <p>guys!</p>
 
@@ -23,21 +22,18 @@ Stuff!</code></pre></figure>
 </div></div><div data-line="2" class="code-highlight-row numbered"><div class="code-highlight-line">    stuff
 </div></div><div data-line="3" class="code-highlight-row numbered"><div class="code-highlight-line">{% some tag that should break %}
 </div></div><div data-line="4" class="code-highlight-row numbered"><div class="code-highlight-line">Stuff!</div></div></pre></div></figure>
-<div class="highlighter-rouge"><pre class="highlight"><code>stuff
+<div class="highlighter-rouge"><div class="highlight"><pre class="highlight"><code>stuff
 {% foo %}
-</code></pre>
-</div>
+</code></pre></div></div>
 
 <p>some text</p>
 
-<div class="highlighter-rouge"><pre class="highlight"><code>{% highlight html %}{% raw %}
+<div class="highlighter-rouge"><div class="highlight"><pre class="highlight"><code>{% highlight html %}{% raw %}
 &lt;article&gt;{{ post.content }}&lt;/article&gt;
 {% endraw %}{% endhighlight %}
-</code></pre>
-</div>
+</code></pre></div></div>
 
 <p>Test inner space block raw replacement:</p>
 
-<div class="highlighter-rouge"><pre class="highlight"><code>This inline {% raw %}`&lt;code&gt;`{% endraw %} tag is escaped.
-</code></pre>
-</div>
+<div class="highlighter-rouge"><div class="highlight"><pre class="highlight"><code>This inline {% raw %}`&lt;code&gt;`{% endraw %} tag is escaped.
+</code></pre></div></div>

--- a/test/_expected/nested-codeblocks.html
+++ b/test/_expected/nested-codeblocks.html
@@ -1,13 +1,12 @@
 <p>hey</p>
 
-<div class="highlighter-rouge"><pre class="highlight"><code><span class="p">{</span><span class="sx">% codeblock </span><span class="n">lang</span><span class="ss">:ruby</span> <span class="n">title</span><span class="ss">:"Check if a number is prime"</span> <span class="n">mark</span><span class="p">:</span><span class="mi">3</span> <span class="o">%</span><span class="p">}</span>
+<div class="language-ruby highlighter-rouge"><div class="highlight"><pre class="highlight"><code><span class="p">{</span><span class="sx">% codeblock </span><span class="n">lang</span><span class="ss">:ruby</span> <span class="n">title</span><span class="ss">:"Check if a number is prime"</span> <span class="n">mark</span><span class="p">:</span><span class="mi">3</span> <span class="o">%</span><span class="p">}</span>
 <span class="k">class</span> <span class="nc">Fixnum</span>
   <span class="k">def</span> <span class="nf">prime?</span>
     <span class="p">(</span><span class="s1">'1'</span> <span class="o">*</span> <span class="nb">self</span><span class="p">)</span> <span class="o">!~</span> <span class="sr">/^1?$|^(11+?)\1+$/</span>
   <span class="k">end</span>
 <span class="k">end</span>
 <span class="p">{</span><span class="sx">% endcodeblock </span><span class="o">%</span><span class="p">}</span>
-</code></pre>
-</div>
+</code></pre></div></div>
 
 <p>guys?</p>


### PR DESCRIPTION
Remove warning by using extname replace ext
Document#ext is now a key in the #data hash.

https://github.com/octopress/codefence/issues/17

Also upgrade ruby version and change test by inspecting newer Jekyll template rendering.